### PR TITLE
Create the container if not exists

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,11 @@
          syntaxCheck="true"
          verbose="true"
 >
+    <php>
+        <env name="FLYSYSTEM_AZURE_CONNECTION_STRING"
+             value="DefaultEndpointsProtocol=..."
+        />
+    </php>
     <testsuites>
         <testsuite name="flysystem/tests">
             <directory suffix="Test.php">./tests/</directory>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
 ## Readme
 
 [View the docs.](https://flysystem.thephpleague.com/docs/)
+
+## UNITARY TEST
+
+Do not forget to complete the phpunit.xml to set the `FLYSYSTEM_AZURE_CONNECTION_STRING` environment variable.

--- a/tests/AzureBlobStorageTest.php
+++ b/tests/AzureBlobStorageTest.php
@@ -31,7 +31,7 @@ class AzureBlobStorageTest extends TestCase
     public function setup_filesystem()
     {
         $this->azureClient = $client = BlobRestProxy::createBlobService(getenv('FLYSYSTEM_AZURE_CONNECTION_STRING'));
-        $adapter = new AzureBlobStorageAdapter($client, 'flysystem', 'root_directory');
+        $adapter = new AzureBlobStorageAdapter($client, 'flysystem', 'root_directory', ['PublicAccess' => 'blob']);
         $this->filesystem = new Filesystem($adapter);
         $this->filesystem->getConfig()->set('disable_asserts', true);
         $this->adapter = $adapter;


### PR DESCRIPTION
This PR improve the adapter 
 - to create the container if it not exists (at the upload) 
 - to define the public access property in case of creation

A bug has been fixed in the `readStream` method by using the path with the prefix (initialized in the `$location` variable)