### PR TITLE
improvement: guess missing mime/content type

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -64,6 +64,12 @@ class AzureBlobStorageAdapter extends AbstractAdapter
     {
         $destination = $this->applyPathPrefix($path);
 
+        $options = $this->getOptionsFromConfig($config);
+
+        if (empty($options->getContentType())) {
+            $options->setContentType(Util::guessMimeType($path, $contents));
+        }
+
         /**
          * We manually create the stream to prevent it from closing the resource
          * in its destructor.
@@ -73,7 +79,7 @@ class AzureBlobStorageAdapter extends AbstractAdapter
             $this->container,
             $destination,
             $contents,
-            $this->getOptionsFromConfig($config)
+            $options
         );
 
         $stream->detach();


### PR DESCRIPTION
The Azure default content type is application/octet-stream. Files content types weren’t being properly identified by Flysystem.

See the note about defaullt content type in Azure Storage Blob package:
https://github.com/Azure/azure-storage-php/blob/272dbba/azure-storage-blob/src/Blob/BlobRestProxy.php#L1784

This is similar to how the AWS S3 v3 Adapter handles content type. See https://github.com/thephpleague/flysystem-aws-s3-v3/blob/15b0cdeab7240bf8e8bffa85ae5275bbc3692bf4/src/AwsS3Adapter.php#L596

This should also fix #11 