### PR TITLE
Change properties from private to protected to allow easy extensions.

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -37,11 +37,11 @@ class AzureBlobStorageAdapter extends AbstractAdapter
     /**
      * @var BlobRestProxy
      */
-    private $client;
+    protected $client;
 
-    private $container;
+    protected $container;
 
-    private $maxResultsForContentsListing = 5000;
+    protected $maxResultsForContentsListing = 5000;
 
     public function __construct(BlobRestProxy $client, $container, $prefix = null)
     {


### PR DESCRIPTION
Currently with these properties being private extending the adapter is basically a full copy/paste.

Changing these properties to protected doesn't change the public API but does allow us to use the client to add/overwrite existing methods.