### PR TITLE
Support guzzlehttp/psr7 v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.6",
         "league/flysystem": "^1.0",
         "microsoft/azure-storage-blob": "^1.1",
-        "guzzlehttp/psr7": "^1.5"
+        "guzzlehttp/psr7": "^1.7|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -2,6 +2,7 @@
 
 namespace League\Flysystem\AzureBlobStorage;
 
+use GuzzleHttp\Psr7\Utils;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Adapter\Polyfill\NotSupportingVisibilityTrait;
 use League\Flysystem\Config;
@@ -16,7 +17,6 @@ use MicrosoftAzure\Storage\Common\Models\ContinuationToken;
 
 use function array_merge;
 use function compact;
-use function GuzzleHttp\Psr7\stream_for;
 use function stream_get_contents;
 use function strpos;
 
@@ -75,7 +75,7 @@ class AzureBlobStorageAdapter extends AbstractAdapter
          * We manually create the stream to prevent it from closing the resource
          * in its destructor.
          */
-        $stream = stream_for($contents);
+        $stream = Utils::streamFor($contents);
         $response = $this->client->createBlockBlob(
             $this->container,
             $destination,


### PR DESCRIPTION
This PR adds compatibility with `guzzlehttp/psr7` v2, resolving conflicts with other packages that require it for Guzzle 7 + PHP 8 compatibility.

The only breaking change this package was affected by was the removal of `GuzzleHttp\Psr7\stream_for`, which had been deprecated/replaced by `GuzzleHttp\Psr7\Utils::streamFor()` in v1.7. So I’ve also bumped the minimum v1 requirement to `^1.7`, and started calling the new method instead.